### PR TITLE
トップページ：PostごとのdiscussページURL生成

### DIFF
--- a/app/Http/Controllers/ApiPostSelectController.php
+++ b/app/Http/Controllers/ApiPostSelectController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Model\Post\post;
+
+
+class ApiPostSelectController extends Controller
+{
+    public function index()
+    {
+        $posts = Post::all();
+        return $posts;
+    }
+    public function store(StorePost $request)
+    // public function store(Request $request)
+    {
+
+    }
+    public function show($id)
+    {
+        //
+    }
+
+    public function update(Request $request, $id)
+    {
+
+    }
+
+    public function destroy($id)
+    {
+
+    }
+}

--- a/app/Http/Controllers/ClaimController.php
+++ b/app/Http/Controllers/ClaimController.php
@@ -10,33 +10,6 @@ use Validator;
 
 class ClaimController extends Controller
 {
-    // public function showCreateForm()
-    // {
-    //     return view('claims_create');
-    // }
-    // public function create(Request $request)
-    // {
-    //     // Claimモデルのインスタンスを作成する
-    //     $claim = new Claim();
-    //     //コンテンツ
-    //     $claim->content = $request->content;
-    //     //登録ユーザーからidを取得
-    //     // $claim->user_id = Auth::user()->id;
-    //     // インスタンスの状態をデータベースに書き込む
-    //     $claim->save();
-    //     //「投稿する」をクリックしたら投稿情報表示ページへリダイレクト       
-    //     return redirect()->route('/discuss/{post}', [
-    //         'id' => $claim->id,
-    //     ]);
-    // }
-
-    // public function detail(Claim $claim)
-    // {
-    //     return view('/discuss/{post}', [
-    //         'content' => $claim->content,
-    //     ]);        
-    // }
-
         //投稿 profileページに、投稿とツイートの変数を渡す
         public function index() 
         {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -28,6 +28,7 @@ import router from './router'
 Vue.component('main-component', require('./components/MainComponent.vue').default);
 import Router from 'vue-router'
 import MyPage from './components/MyPage';
+import Discuss from './components/DiscussComponent';
 
 
 // トップページのお花畑
@@ -52,7 +53,8 @@ const app = new Vue({
         }
     }),
     components: {
-        "mypage-component": MyPage
+        "mypage-component": MyPage,
+        "discuss-component": Discuss, 
     },
 });
 

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -21,7 +21,13 @@ try {
 
 window.axios = require('axios');
 
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+// 変更・追記
+window.axios.defaults.headers.common = {
+    // 'X-CSRF-TOKEN': window.Laravel.csrfToken,
+    'X-Requested-With': 'XMLHttpRequest'
+}
+// 変更・追記
+// Vue.prototype.$http = window.axios
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening

--- a/resources/js/components/DiscussComponent.vue
+++ b/resources/js/components/DiscussComponent.vue
@@ -1,0 +1,26 @@
+<template>
+    <!-- 論点の可視化 -->
+    <section>
+        <!-- Post情報 -->
+        <div>
+            <button type="button" class="btn btn-primary ">
+                Post_info
+            </button>
+        </div>
+        <!-- 論点の可視化 -->
+        <div class="discuss_point_visualize">
+            <div>
+                論点の可視化を表示させたい
+            </div>
+        </div>
+        <p>{{ id }}</p>
+    </section>
+
+</template>
+
+<script>
+    // propsでidを受け取るようにすると同時に、Numberでデータ型も指定する
+    export default {
+        props: { id: Number }
+    }
+</script>

--- a/resources/js/components/ImageComponent.vue
+++ b/resources/js/components/ImageComponent.vue
@@ -15,10 +15,13 @@
                         class="mx-auto"
                         width="344"
                     >
-                        <v-img
-                        :src="`${post.img_url}`"
-                        height="200px"
-                        ></v-img>
+                        <router-link :to="'/discuss/' + post.id">
+                            <v-img
+                            :src="`${post.img_url}`"
+                            height="200px"
+                            >
+                            </v-img>
+                        </router-link>
 
                         <v-card-title>
                             {{ post.title }}
@@ -82,6 +85,10 @@ import { mdiShare } from '@mdi/js';
 import { mdiHeartPlus } from '@mdi/js';
 
 export default {
+    // Postのページ出し分け
+    created() {
+        this.fetchPosts()
+    },
     data() {
         return {
             message: "",
@@ -93,14 +100,7 @@ export default {
             confirmedImage: "",
             //カードの開封 
             show: false,
-            // カードユニット
-                justify: [
-            // 'start',
-            // 'end',
-            // 'center',
-            // 'space-between',
-            'space-around',
-            ],
+            // アイコン
             svgPath: mdiShare,
             svgPath_2: mdiHeartPlus,
         };
@@ -117,6 +117,16 @@ export default {
                 })
                 .catch(err => {
                     this.message = err;
+                });
+        },
+        fetchPosts() {
+            this.$http
+                .get('/api/posts')
+                .then(response =>  {
+                    this.posts = response.data;
+                })
+                .finally(function(){
+                location.reload(true);
                 });
         },
         confirmImage(e) {
@@ -161,8 +171,6 @@ export default {
                 .catch(err => {
                     this.message = err.response.data.errors;
                 });
-        }
-    }
-};
+        },
+}}
 </script>
- 

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -10,6 +10,7 @@ import HeaderComponent from './components/HeaderComponent'
 import UserImageName from './components/UserImageName'
 import MyPageSelecter from './components/MyPageSelecter'
 import Footer from './components/Footer'
+import DiscussComponent from './components/DiscussComponent'
 
 // Views/Homeのテスト
 import Home from './views/Home'
@@ -38,8 +39,17 @@ const router = new Router({
           mypageSelecter: MyPageSelecter,
           footer: Footer,
         },
-      
-    }
+      },
+      {
+        //
+        //(\\d+)を付ければパラメータには数字しか入らない正規表現となる 
+        path: '/discuss/:id(\\d+)', 
+        name: 'discuss',
+        component: { 
+          default: DiscussComponent
+        },
+        props: route => ({ id: Number(route.params.id) })
+      },
   ]
 })
 

--- a/resources/views/testapi.blade.php
+++ b/resources/views/testapi.blade.php
@@ -9,7 +9,7 @@
 
 <body>
     <div id="app">
-        <testapi-component></testapi-component>
+        <discuss-component/>
     </div>
 
     <script src="{{ mix('js/app.js') }}"></script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,8 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::apiResource('/tests', 'ApiPostController');
 
 Route::apiResource('/images', 'ApiImageController');
+
+// // URL生成テスト(Post投稿ごとのidでページを作成できるようにしたい)
+Route::group(['middleware' => 'api'], function() {
+    Route::get('posts', 'ApiPostSelectController@index');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,9 @@ Route::get('/mypage', 'UserController@index');
 Route::get('/tags', 'TagsController@index');
 
 // ★ディスカッションページ★
-Route::get('/discuss/{post}', 'ClaimController@index');
+
+// $post = App\Model\Post\Post::find(1);
+// Route::get('/discuss/{$post->id}', 'ClaimController@index');
 
 // ディスカッションページ＠意見投稿 
 Route::post('/claim', 'ClaimController@store');
@@ -37,7 +39,13 @@ Route::post('/claim', 'ClaimController@store');
 // Route::get('/discuss/{post}', 'ClaimController@detail')->name('claims.detail');
 
 // API連携テスト
-Route::get('/testapi', 'TestApiController@index');
+// Route::get('testapi', 'TestApiController@index');
 
 // 画像アップロードテスト
 Route::get('/image', 'ImageController@index');
+
+// URL生成テスト(Post投稿ごとのidでページを作成できるようにしたい)
+Route::get('/discuss/{any}', function () {
+    return view('testapi');
+})->where('any', '.*');
+


### PR DESCRIPTION
進捗：URLごとの生成には成功？(/discuss/:id)
つまりポイント：ページ遷移ができない
→URLの欄には、「~/discuss/27」と表示される
→しかし、ページ遷移はされず、indexのページのまま 
→ただ、エラーが吐かれない

仮説とメモ書き：
・router-linkがうまくいっていない？
・axiosのところでミスっている？
・そもそも、router-link先に繋げる処理をしていない？
(→それなら、404エラーがでるか。router-linkは、URL欄に、/discuss/:idのように表記するだけってこと？実際にリクエストするのは別の処理ってことかな？）